### PR TITLE
Refactor: Maximum of 1000 entries per json file.

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3,14 +3,15 @@
  */
 
 // Global state variables
-let data = [];
-let index = 0;
-let step = 50;
+let data = new Map(); // Use Map instead of array for better memory management
+let index = 0; // Current overall index across all loaded pages
+let currentPage = 1;
+let totalPages = 1;
+let filesPerPage = 1000; // Default, will be updated from meta.json
 let type = "";
 let modalIndex = -1;
 let detailsVisible = false;
 let loadingMore = false;
-let allFileStats = {};
 let endReached = false;
 let imageObserver;
 let currentAudio = null;
@@ -109,14 +110,12 @@ function setupInfiniteScroll() {
   window.onscroll = function () {
     if (loadingMore || endReached) return;
 
+    // Check if user is near the bottom
     if (
       window.innerHeight + window.scrollY >=
-      document.body.offsetHeight - 200
+      document.body.offsetHeight - 500 // Increased threshold slightly
     ) {
-      loadingMore = true;
-      render().then(() => {
-        loadingMore = false;
-      });
+      loadPage(currentPage + 1); // Load the next page
     }
   };
 }
@@ -173,7 +172,164 @@ function setupResizeObserver() {
 }
 
 /**
- * Check if more content needs to be loaded when there's not enough to fill the viewport
+ * Load the first page of a category
+ * @param {string} t - Category type to load
+ */
+async function loadCategory(t) {
+  type = t;
+  index = 0;
+  currentPage = 1;
+  data.clear(); // Clear previous data
+  endReached = false;
+  loadingMore = false; // Reset loading flag
+
+  updateActiveNav(t);
+  document.getElementById("intro").style.display = "none";
+  document.body.setAttribute("data-category", t);
+
+  const container = document.getElementById("container");
+  container.innerHTML = ""; // Clear container
+  container.className = "container"; // Reset classes
+
+  // Get pagination info for this type from allFileStats (loaded by fetchAllStats)
+  const stats = allFileStats[t];
+  if (!stats || stats.totalFiles === 0) {
+    totalPages = 0;
+    filesPerPage = 0;
+    container.innerHTML = `<p>No files found in the '${t}' category.</p>`;
+    endReached = true;
+    return; // Nothing to load
+  }
+
+  totalPages = stats.totalPages;
+  filesPerPage = stats.filesPerPage;
+
+  // Setup initial view (table or card)
+  if (shouldUseTableView(t)) {
+    const table = createTableStructure(t);
+    container.appendChild(table);
+    const tbody = table.querySelector("tbody");
+    tbody.innerHTML = `
+          <tr class="loading-placeholder">
+              <td colspan="${t === "audio" ? 4 : 3}" class="loading-container">
+                  <div class="spinner"></div> <p>Loading files...</p>
+              </td>
+          </tr>
+      `;
+  } else {
+    setupCardView(container, t);
+    container.innerHTML =
+      '<div class="loading-container loading-placeholder"><div class="spinner"></div><p>Loading files...</p></div>';
+  }
+
+  // Load the first page
+  await loadPage(1);
+}
+
+/**
+ * Load a specific page of files for the current category
+ * @param {number} pageNum - The page number to load
+ */
+async function loadPage(pageNum) {
+  if (loadingMore || pageNum > totalPages) {
+    endReached = true;
+    // Remove any final loading indicator if it exists
+    const loadingPlaceholder = document.querySelector(".loading-placeholder");
+    if (loadingPlaceholder) loadingPlaceholder.remove();
+    return;
+  }
+
+  loadingMore = true;
+  console.log(`Loading page ${pageNum} for type ${type}`);
+
+  const container = document.getElementById("container");
+  const loadingPlaceholder = document.querySelector(".loading-placeholder");
+
+  try {
+    const jsonPath = `${type}_${pageNum}.json`;
+    const response = await fetch(jsonPath);
+
+    if (!response.ok) {
+      // Handle 404 for the specific page (might happen with fallback logic)
+      if (response.status === 404 && allFileStats[type]?.isLegacy) {
+        console.warn(`Legacy file ${type}.json not found or empty.`);
+        endReached = true;
+      } else {
+        throw new Error(`HTTP error ${response.status} fetching ${jsonPath}`);
+      }
+      if (loadingPlaceholder) loadingPlaceholder.remove();
+      loadingMore = false;
+      return; // Stop loading this page
+    }
+
+    const files = await response.json();
+
+    // Remove loading placeholder before rendering
+    if (loadingPlaceholder) loadingPlaceholder.remove();
+
+    if (files.length > 0) {
+      // Store files in the Map (using current index as part of key for uniqueness if needed, or just path)
+      files.forEach((file, i) => {
+        data.set(index + i, file); // Use running index as key
+      });
+
+      // Render the newly loaded files
+      renderPage(files);
+      currentPage = pageNum;
+    } else {
+      endReached = true;
+      console.log("Reached end, no more files in page", pageNum);
+    }
+
+    loadingMore = false;
+
+    // Check if we need to load *more* pages immediately (if viewport isn't full)
+    // Use a small delay to allow rendering to complete
+    setTimeout(checkForMoreContent, 100);
+  } catch (error) {
+    console.error(`Error loading page ${pageNum} for ${type}:`, error);
+    if (loadingPlaceholder) loadingPlaceholder.remove();
+    container.innerHTML += `<div class="error-container">
+      <h3>Error Loading Page ${pageNum}</h3>
+      <p>${error.message}</p>
+      <button onclick="loadPage(${pageNum})">Try Again</button>
+    </div>`;
+    loadingMore = false;
+    endReached = true; // Stop trying to load more on error
+  }
+}
+
+/**
+ * Render a specific page/batch of files
+ * @param {Array<FileInfo>} filesToRender - The files to append to the view
+ */
+function renderPage(filesToRender) {
+  if (!filesToRender || filesToRender.length === 0) {
+    return;
+  }
+
+  const container = document.getElementById("container");
+  const isTableView = shouldUseTableView(type);
+  const startIndex = index; // Keep track of starting index for this batch
+
+  if (isTableView) {
+    const tbody = container.querySelector("tbody");
+    if (tbody) {
+      // Ensure tbody exists
+      renderTableView(tbody, filesToRender, startIndex);
+    } else {
+      console.error("Table body not found for rendering!");
+    }
+  } else {
+    renderCardView(container, filesToRender, startIndex);
+  }
+
+  // Update the main index *after* rendering this batch
+  index += filesToRender.length;
+}
+
+/**
+ * Check if more content needs to be loaded (loads next page if needed)
  */
 function checkForMoreContent() {
   if (loadingMore || endReached) return;
@@ -182,20 +338,12 @@ function checkForMoreContent() {
   const documentHeight = document.body.offsetHeight;
   const scrollPosition = window.scrollY;
 
-  // Load more content if not enough to fill viewport or close to bottom
+  // Load *next page* if not enough content to fill viewport or close to bottom
   if (
     documentHeight < viewportHeight * 1.5 ||
     scrollPosition + viewportHeight > documentHeight - 500
   ) {
-    loadingMore = true;
-    render().then(() => {
-      loadingMore = false;
-
-      // Use requestAnimationFrame instead of setTimeout for better performance
-      // and to prevent stack overflow
-      if (!endReached && document.body.offsetHeight < viewportHeight * 1.5) {
-        requestAnimationFrame(checkForMoreContent);
-      }
-    });
+    // We don't call render directly anymore, we call loadPage
+    loadPage(currentPage + 1);
   }
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -31,7 +31,7 @@ window.addEventListener("DOMContentLoaded", function () {
   debugLogging = document.body.getAttribute("data-debug-enabled") === "true";
   window.debugLog = function (message, ...args) {
     if (debugLogging) {
-      window.debugLog("[DEBUG]", message, ...args);
+      console.debug("[DEBUG]", message, ...args);
     }
   };
   initApp();

--- a/static/js/modals.js
+++ b/static/js/modals.js
@@ -322,9 +322,9 @@ function showVideoModal(file, videoIndex) {
       window.debugLog("Autoplay prevented or failed:", e);
     });
     // Remove listener after first trigger
-    cleanVideoPlayer.removeEventListener("canplay", playPromiseHandler);
+    cleanVideoPlayer.removeEventListener("canplaythrough", playPromiseHandler);
   };
-  cleanVideoPlayer.addEventListener("canplay", playPromiseHandler);
+  cleanVideoPlayer.addEventListener("canplaythrough", playPromiseHandler);
 
   // Handle potential errors loading the video source
   const errorHandler = (e) => {

--- a/template/index.html
+++ b/template/index.html
@@ -18,15 +18,31 @@
     data-debug-enabled="{{.DebugLogging}}"
   >
     <div class="nav" id="navbar">
-      <a onclick="showIntro()" class="active" data-category="home">🏠 Home</a>
-      <a onclick="load('image')" data-category="image">Images</a>
-      <a onclick="load('video')" data-category="video">Videos</a>
-      <a onclick="load('audio')" data-category="audio">Audio</a>
-      <a onclick="load('text')" data-category="text">Text Docs</a>
-      <a onclick="load('code')" data-category="code">Code Files</a>
-      <a onclick="load('pdf')" data-category="pdf">PDFs</a>
-      <a onclick="load('archive')" data-category="archive">Archives</a>
-      <a onclick="load('other')" data-category="other">Other</a>
+      <a href="#" data-category="home" onclick="showIntro()" class="active"
+        >🏠 Home</a
+      >
+      <a href="#" data-category="image" onclick="loadCategory('image')"
+        >Images</a
+      >
+      <a href="#" data-category="video" onclick="loadCategory('video')"
+        >Videos</a
+      >
+      <a href="#" data-category="audio" onclick="loadCategory('audio')"
+        >Audio</a
+      >
+      <a href="#" data-category="text" onclick="loadCategory('text')"
+        >Text Docs</a
+      >
+      <a href="#" data-category="code" onclick="loadCategory('code')"
+        >Code Files</a
+      >
+      <a href="#" data-category="pdf" onclick="loadCategory('pdf')">PDFs</a>
+      <a href="#" data-category="archive" onclick="loadCategory('archive')"
+        >Archives</a
+      >
+      <a href="#" data-category="other" onclick="loadCategory('other')"
+        >Other</a
+      >
       <span class="spacer"></span>
       <a onclick="zoomIn()" title="Zoom In" class="zoom-control">🔍+</a>
       <a onclick="zoomOut()" title="Zoom Out" class="zoom-control">🔍-</a>


### PR DESCRIPTION
**Problem**: Loading all file information (potentially hundreds of thousands) into memory at once in both the Go backend and the JavaScript frontend was identified as a major performance bottleneck and potential source of memory issues or crashes.

## Fixes

### Go backend

- Modified scanDirectory in localpics.go to process files and write data out incrementally.
- Instead of one large JSON file per category (e.g., image.json), it now creates numbered page files (e.g., image_1.json, image_2.json, ...) with a fixed number of entries (filesPerPage = 1000).
- Added generation of a meta.json file containing metadata about each category (total file count, pages, files per page).

### Frontend

- Updated fetchAllStats in static/js/fileLoader.js to first fetch meta.json to get the overall counts and pagination details. Added fallback logic in case meta.json doesn't exist (for small directories or older structures).
- Introduced loadCategory to initialize the view for a selected category based on meta.json.
- Introduced loadPage to fetch a specific page's JSON file (e.g., image_2.json).
- Introduced renderPage to append the files from a newly loaded page to the DOM.
- Modified the infinite scroll (onscroll) and checkForMoreContent logic to call loadPage for the next page number instead of rendering slices of an existing large array.
- Removed the old load and render functions that assumed all data was loaded upfront.
- Updated navigation links in template/index.html to call the new loadCategory function.

## Possible issues or things that need addressing:

- While pagination helps load data incrementally, all loaded items currently stay in the DOM. For extremely large categories, this can still slow down the browser. Implementing DOM virtualization (only rendering visible elements) would significantly improve performance in those cases, although it adds complexity.
- Complementary to DOM virtualization, we could implement a strategy to remove file data from the data Map in JS for pages that are far scrolled away, freeing up JS memory. This needs careful handling for features like the image modal.

[auto] prettier applied to JavaScript, CSS, and HTML files